### PR TITLE
Increase fullscreen detection tolerance to 80px for Raspberry Pi

### DIFF
--- a/MasjidUmarWebsiteFirebase/public/live_view.html
+++ b/MasjidUmarWebsiteFirebase/public/live_view.html
@@ -659,8 +659,8 @@
 	function checkFullscreen() {
 		var isApiFullscreen = !!(document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement);
 		var isF11Fullscreen = (
-			Math.abs(window.innerHeight - screen.height) <= 5 &&
-			Math.abs(window.innerWidth - screen.width) <= 5
+			Math.abs(window.innerHeight - screen.height) <= 80 &&
+			Math.abs(window.innerWidth - screen.width) <= 80
 		);
 		inFullscreen = isApiFullscreen || isF11Fullscreen || (isIOS && isStandalone);
 		if (inFullscreen) {


### PR DESCRIPTION
## Summary
- Widens the `isF11Fullscreen` viewport/screen dimension tolerance from 5px to 80px
- Fixes fullscreen detection on Raspberry Pi OS where Chromium's viewport can differ from `screen.height` by up to ~40px due to the OS taskbar
- No change in behavior for regular desktop browsers (maximized window diff is ~120px+, safely above the threshold)

## Test plan
- [ ] Open `live_view.html` in a normal windowed browser — Fullscreen and B&W buttons visible
- [ ] Press F11 or click Fullscreen — buttons disappear
- [ ] On Raspberry Pi with Chromium kiosk/fullscreen startup — buttons disappear automatically